### PR TITLE
add flash commands for softdevice and firmware w/daplink

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,9 +2,39 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Cortex Debug",
+            "name": "Debug",
             "cwd": "${workspaceFolder}",
             "executable": "_build/nrf52832_xxaa_debug.out",
+            "request": "launch",
+            "type": "cortex-debug",
+            "runToEntryPoint": "main",
+            "servertype": "openocd",
+            "device": "nrf52",
+            "configFiles": [
+                "interface/cmsis-dap.cfg",
+                "target/nrf52.cfg"
+            ],   
+            "openOCDLaunchCommands": ["adapter speed 2000"],
+            "interface": "swd",
+            "armToolchainPath": "",
+            "svdFile": "${workspaceRoot}/nrf52832.svd",
+            "preLaunchCommands":["set remotetimeout 60"],
+            "rttConfig": {
+                "enabled": true,
+                "address": "auto",
+                "clearSearch": false,   // OpenOCD users may have to un-comment this
+                "decoders": [
+                    {
+                        "port": 0,
+                        "type": "console"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Release",
+            "cwd": "${workspaceFolder}",
+            "executable": "_build/nrf52832_xxaa_release.out",
             "request": "launch",
             "type": "cortex-debug",
             "runToEntryPoint": "main",

--- a/Makefile
+++ b/Makefile
@@ -332,5 +332,32 @@ logs:
 	socat pty,link=/tmp/ttyvnrf,waitslave tcp:127.0.0.1:8000 & disown
 	picocom /tmp/ttyvnrf -b 115200
 
-flash_with_gdb:
-	arm-none-eabi-gdb -e _build/nrf52832_xxaa_release.out -x flash.gdb
+daplink_erase_flash:
+	@echo Erase flash
+	openocd -f interface/cmsis-dap.cfg -f target/nrf52.cfg \
+  -c "init" -c "reset init" -c "nrf5 mass_erase" \
+  -c "reset" -c "exit"
+
+# flash the bluetooth stack using the DAPlink
+daplink_flash_softdevice: daplink_erase_flash
+	@echo Flashing: s132_nrf52_6.1.1_softdevice.hex
+	openocd -f interface/cmsis-dap.cfg -f target/nrf52.cfg \
+  -c "init" -c "reset init" \
+  -c "program $(SDK_ROOT)/components/softdevice/s132/hex/s132_nrf52_6.1.1_softdevice.hex" \
+  -c "reset" -c "exit"
+
+daplink_flash_debug: nrf52832_xxaa_debug
+	@echo Flashing Debug Firmware
+	openocd -f interface/cmsis-dap.cfg -f target/nrf52.cfg \
+  -c "init" -c "reset init" \
+  -c "program $(OUTPUT_DIRECTORY)/nrf52832_xxaa_debug.hex" \
+  -c "reset" -c "exit"
+
+
+daplink_flash_release: nrf52832_xxaa_release 
+	@echo Flashing Debug Firmware
+	openocd -f interface/cmsis-dap.cfg -f target/nrf52.cfg \
+  -c "init" -c "reset init" \
+  -c "program $(OUTPUT_DIRECTORY)/nrf52832_xxaa_release.hex" \
+  -c "reset" -c "exit"
+

--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,7 @@ logs:
 	socat pty,link=/tmp/ttyvnrf,waitslave tcp:127.0.0.1:8000 & disown
 	picocom /tmp/ttyvnrf -b 115200
 
+# Erases code sectors and user info regs
 daplink_erase_flash:
 	@echo Erase flash
 	openocd -f interface/cmsis-dap.cfg -f target/nrf52.cfg \

--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ Example `launch.json` for using Cortex-Debug for flashing and debugging
 
 ## Flashing the final binary
 
-1. Build with `make nrf52832_xxaa_release`
-2. Start the openocd server with `make openocd`
-3. Flash the binary with `make flash_with_gdb`
+### DAPLink
+
+1. Flash the softdevice (only required once): `make daplink_flash_softdevice`
+1. Build with `make nrf52832_xxaa_<release|debug>`
+3. Flash the binary with `make daplink_flash_<release|debug>`
 
 ## Hardware
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,26 @@ Example `launch.json` for using Cortex-Debug for flashing and debugging
 
 ## Flashing the final binary
 
+### About the BLE stack AKA softdevice 
+
+A softdevice is basically the stack used for controlling the different radios 
+in a nRF chip. It's a binary that must be flashed before other firmware. It can 
+be downloaded as a standalone binary, altough if you already had the nRF5 SDK 
+downloaded, it's probably already coupled with it. You should be able to find it
+at `$(SDK_ROOT)/components/softdevice/s132/hex/s132_nrf52_6.1.1_softdevice.hex`.
+The standalone files can be downloaded from
+<https://www.nordicsemi.com/Products/Development-software/S132/Download>
+
 ### DAPLink
 
 1. Flash the softdevice (only required once): `make daplink_flash_softdevice`
-1. Build with `make nrf52832_xxaa_<release|debug>`
+  - This by itself will call the `daplink_erase_flash` target which erases 
+    contents of code memory and config registers
+2. Build with `make nrf52832_xxaa_<release|debug>`
 3. Flash the binary with `make daplink_flash_<release|debug>`
+
+> Calling the `daplink_erase_flash` target is not a requirement to update 
+  firmware after the softdevice has been flashed
 
 ## Hardware
 

--- a/flash.gdb
+++ b/flash.gdb
@@ -1,7 +1,0 @@
-set remotetimeout 60
-target extended-remote :3333
-set print asm-demangle on
-load 
-set confirm off
-quit
-


### PR DESCRIPTION
Technically covers #6 and #8, although the issues seen in #6 related to external cpu reset were not found in the daplink flow. Let's test the new commands using the DAPLink setup from SPCL 