### PR TITLE
audio: add timestamp to raw files

### DIFF
--- a/microphone/drv_audio_pdm.c
+++ b/microphone/drv_audio_pdm.c
@@ -18,6 +18,7 @@
 #include "storage.h"
 #include "audio_switch.h"
 #include "sampling_lib.h"
+#include "systick_lib.h"
 
 ret_code_t err_code;
 
@@ -29,13 +30,13 @@ nrf_pdm_mode_t local_mode;
 uint32_t local_freq;
 uint8_t local_gain_l;
 uint8_t local_gain_r;
-
+uint64_t timestamp_buffer[PDM_BUF_NUM];
 
 int16_t subsampled[PDM_BUF_SIZE/DECIMATION];
 float filter_weight[DECIMATION];
 
 
-static void process_audio_buffer(void)
+static void process_audio_buffer(uint8_t buffer_index)
 {
 	switch (audio_switch_position)
 	{
@@ -47,6 +48,7 @@ static void process_audio_buffer(void)
 		{
 			data_source_info.data_source = AUDIO;
 			data_source_info.audio_source_info.audio_buffer_length = PDM_BUF_SIZE*2;
+			data_source_info.audio_source_info.buffer_index = buffer_index;
 			err_code = app_sched_event_put(&data_source_info, sizeof(data_source_info), sd_write);
 			APP_ERROR_CHECK(err_code);
 		}
@@ -69,6 +71,7 @@ static void process_audio_buffer(void)
 			}
 
 			data_source_info.data_source = AUDIO;
+			data_source_info.audio_source_info.buffer_index = buffer_index;
 			data_source_info.audio_source_info.audio_buffer = subsampled;
 			data_source_info.audio_source_info.audio_buffer_length = (PDM_BUF_SIZE/DECIMATION)*2; //sizeof(subsampled);
 			err_code = app_sched_event_put(&data_source_info, sizeof(data_source_info), sd_write);
@@ -101,8 +104,9 @@ static void drv_audio_pdm_event_handler(nrfx_pdm_evt_t const * const p_evt)
 			{
 				pdm_buf[l].released = true;
 				data_source_info.audio_source_info.audio_buffer = &pdm_buf[l].mic_buf;
+				timestamp_buffer[l] = systick_get_millis();
 				NRF_LOG_INFO("pdm buf %d", pdm_buf[l].mic_buf[0]);
-				process_audio_buffer();
+				process_audio_buffer(l);
 				break;
 			}
 		}

--- a/microphone/drv_audio_pdm.c
+++ b/microphone/drv_audio_pdm.c
@@ -113,11 +113,7 @@ static void drv_audio_pdm_event_handler(nrfx_pdm_evt_t const * const p_evt)
 					const uint32_t base_sample_rate = 20000; // 20kHz
 					uint64_t current_time = systick_get_millis();
 					uint32_t buffer_duration = (PDM_BUF_SIZE / base_sample_rate) * 1000;
-					if (current_time >= buffer_duration) {
-						timestamp_buffer[l] = current_time - buffer_duration;
-					} else {
-						timestamp_buffer[l] = current_time;
-					}
+					timestamp_buffer[l] = current_time - buffer_duration;
 				}				
 				NRF_LOG_INFO("pdm buf %d", pdm_buf[l].mic_buf[0]);
 				process_audio_buffer(l);

--- a/microphone/drv_audio_pdm.c
+++ b/microphone/drv_audio_pdm.c
@@ -110,9 +110,14 @@ static void drv_audio_pdm_event_handler(nrfx_pdm_evt_t const * const p_evt)
 				} else {
 					// Subsequent buffers
 					// t_rec_i = t_release_i - (PDM_BUF_SIZE / effective_sampling_rate) * 1000
-					uint32_t base_sample_rate = 20000; // 20kHz
-					uint32_t effective_sampling_rate = drv_audio_get_mode() == 0 ? base_sample_rate/2 : base_sample_rate;
-					timestamp_buffer[l] = systick_get_millis() - (PDM_BUF_SIZE / effective_sampling_rate) * 1000;
+					const uint32_t base_sample_rate = 20000; // 20kHz
+					uint64_t current_time = systick_get_millis();
+					uint32_t buffer_duration = (PDM_BUF_SIZE / base_sample_rate) * 1000;
+					if (current_time >= buffer_duration) {
+						timestamp_buffer[l] = current_time - buffer_duration;
+					} else {
+						timestamp_buffer[l] = current_time;
+					}
 				}				
 				NRF_LOG_INFO("pdm buf %d", pdm_buf[l].mic_buf[0]);
 				process_audio_buffer(l);

--- a/microphone/drv_audio_pdm.c
+++ b/microphone/drv_audio_pdm.c
@@ -181,6 +181,7 @@ ret_code_t drv_audio_init(nrf_pdm_mode_t mode, uint64_t timestamp)
 	//! position. The HW in the uC is designed for this frequency but Nordic 
 	//! does not support it oficially as it's not considered tested enough 
 	//! https://devzone.nordicsemi.com/f/nordic-q-a/15150/single-pdm-microphone-at-higher-pcm-sampling-rate
+	//! NOTE: Change the clock frequency in the `drv_audio_pdm_event_handler` function if this is changed.
 	pdm_cfg.clock_freq	= 0x0A000000UL; 
 	local_freq      = pdm_cfg.clock_freq;
 

--- a/microphone/drv_audio_pdm.h
+++ b/microphone/drv_audio_pdm.h
@@ -28,6 +28,6 @@ int8_t drv_audio_get_gain_l(void);
 int8_t drv_audio_get_gain_r(void);
 int16_t drv_audio_get_pdm_freq(void);
 
-ret_code_t drv_audio_init(nrf_pdm_mode_t mode);
+ret_code_t drv_audio_init(nrf_pdm_mode_t mode, uint64_t timestamp);
 
 #endif /* __DRV_AUDIO_PDM_H__ */

--- a/rythmbadge/request_handler_lib.c
+++ b/rythmbadge/request_handler_lib.c
@@ -230,7 +230,7 @@ static ret_code_t receive_notification_fifo_peek(receive_notification_t* receive
 	}
 	
 	uint8_t tmp[notification_size];
-	memset(tmp, 0, notification_size * sizeof(uint8_t));
+	memset(tmp, 0, sizeof(tmp));
 	for(uint32_t i = 0; i < notification_size; i++) {
 		app_fifo_peek(&receive_notification_fifo, i + index*notification_size, &(tmp[i]));
 	}

--- a/rythmbadge/request_handler_lib.c
+++ b/rythmbadge/request_handler_lib.c
@@ -230,6 +230,7 @@ static ret_code_t receive_notification_fifo_peek(receive_notification_t* receive
 	}
 	
 	uint8_t tmp[notification_size];
+	memset(tmp, 0, notification_size * sizeof(uint8_t));
 	for(uint32_t i = 0; i < notification_size; i++) {
 		app_fifo_peek(&receive_notification_fifo, i + index*notification_size, &(tmp[i]));
 	}

--- a/rythmbadge/sampling_lib.c
+++ b/rythmbadge/sampling_lib.c
@@ -105,7 +105,7 @@ ret_code_t sampling_start_microphone(nrf_pdm_mode_t mode)
 	if (audio_switch_get_position()==OFF)
 		return ret;
 
-	memset(timestamp_buffer, 0, sizeof timestamp_buffer);
+	memset(timestamp_buffer, 0, sizeof(timestamp_buffer));
 	uint64_t initial_recording_timestamp = systick_get_millis();
 
 	ret = drv_audio_init(mode, initial_recording_timestamp);

--- a/rythmbadge/sampling_lib.c
+++ b/rythmbadge/sampling_lib.c
@@ -17,6 +17,7 @@
 #include "led.h"
 
 static sampling_configuration_t sampling_configuration;
+extern uint64_t timestamp_buffer[PDM_BUF_NUM];
 
 ret_code_t sampling_init(void)
 {
@@ -104,7 +105,10 @@ ret_code_t sampling_start_microphone(nrf_pdm_mode_t mode)
 	if (audio_switch_get_position()==OFF)
 		return ret;
 
-	ret = drv_audio_init(mode);
+	memset(timestamp_buffer, 0, sizeof timestamp_buffer);
+	uint64_t initial_recording_timestamp = systick_get_millis();
+
+	ret = drv_audio_init(mode, initial_recording_timestamp);
 	if(ret != NRF_SUCCESS) return ret;
 
 	ret = storage_open_file(AUDIO);

--- a/sd_card/storage.c
+++ b/sd_card/storage.c
@@ -62,8 +62,6 @@ void sd_write(void * p_event_data, uint16_t event_size)
 	{
 		audio_metadata_t audio_metadata_record;
 		audio_metadata_record.timestamp = timestamp_buffer[data_source_info.audio_source_info.buffer_index];
-		audio_metadata_record.buffer_size = data_source_info.audio_source_info.audio_buffer_length;
-		audio_metadata_record.is_mono = (drv_audio_get_mode() == 1);
 
 		ff_result = f_write(&audio_metadata_file_handle, &audio_metadata_record, sizeof(audio_metadata_t), NULL);
 		if (ff_result != FR_OK)

--- a/sd_card/storage.c
+++ b/sd_card/storage.c
@@ -41,18 +41,16 @@ FIL audio_file_handle;
 FIL audio_metadata_file_handle;
 FIL imu_file_handle[MAX_IMU_SOURCES];
 FIL scanner_file_handle;
-
+extern uint64_t timestamp_buffer[PDM_BUF_NUM];
 
 void sd_write(void * p_event_data, uint16_t event_size)
 {
 	static data_source_info_t data_source_info;
 	data_source_info = *(data_source_info_t *)p_event_data;
-	uint64_t timestamp;
 
 	if (data_source_info.data_source == AUDIO && !audio_file_handle.err)
 	{
 		app_timer_start(f_write_timeout_timer, APP_TIMER_TICKS(F_WRITE_TIMEOUT_MS), &data_source_info.data_source);
-		timestamp = systick_get_millis();
 		// size is times two, since this function receives number of bytes, not size of pointer
 		FRESULT ff_result = f_write(&audio_file_handle, data_source_info.audio_source_info.audio_buffer, data_source_info.audio_source_info.audio_buffer_length, NULL);
 		if (ff_result != FR_OK)
@@ -63,7 +61,7 @@ void sd_write(void * p_event_data, uint16_t event_size)
 	if (!audio_metadata_file_handle.err)
 	{
 		audio_metadata_t audio_metadata_record;
-		audio_metadata_record.timestamp = timestamp;
+		audio_metadata_record.timestamp = timestamp_buffer[data_source_info.audio_source_info.buffer_index];
 		audio_metadata_record.buffer_size = data_source_info.audio_source_info.audio_buffer_length;
 		audio_metadata_record.is_mono = (drv_audio_get_mode() == 1);
 

--- a/sd_card/storage.h
+++ b/sd_card/storage.h
@@ -38,9 +38,6 @@ typedef struct {
 
 typedef struct __attribute__((__packed__)) {
 	uint64_t timestamp;
-	uint16_t buffer_size;
-	uint8_t is_mono;
-	uint8_t padding;
 } audio_metadata_t;
 
 typedef struct __attribute__((__packed__)) {

--- a/sd_card/storage.h
+++ b/sd_card/storage.h
@@ -36,8 +36,7 @@ typedef struct {
 } audio_source_info_t;
 
 typedef struct __attribute__((__packed__)) {
-	uint32_t seconds;
-	uint16_t milliseconds;
+	uint64_t timestamp;
 	uint16_t buffer_size;
 	uint8_t is_mono;
 	uint8_t padding;

--- a/sd_card/storage.h
+++ b/sd_card/storage.h
@@ -36,6 +36,14 @@ typedef struct {
 } audio_source_info_t;
 
 typedef struct __attribute__((__packed__)) {
+	uint32_t seconds;
+	uint16_t milliseconds;
+	uint16_t buffer_size;
+	uint8_t is_mono;
+	uint8_t padding;
+} audio_metadata_t;
+
+typedef struct __attribute__((__packed__)) {
 	data_source_t data_source;
 	union{
 		audio_source_info_t audio_source_info;

--- a/sd_card/storage.h
+++ b/sd_card/storage.h
@@ -31,6 +31,7 @@ typedef struct {
 } imu_source_info_t;
 
 typedef struct {
+	uint8_t buffer_index;
 	uint16_t audio_buffer_length;
 	const void * audio_buffer;
 } audio_source_info_t;


### PR DESCRIPTION
Fix #9 

Creates a new file with a `.D` extension containing the following data per audio sample.
```
typedef struct __attribute__((__packed__)) {
	uint32_t seconds;
	uint16_t milliseconds;
	uint16_t buffer_size;
	uint8_t is_mono;
	uint8_t padding;
} audio_metadata_t;
```