### PR TITLE
fix: correct audio frequency decoding script. fixes #11

### DIFF
--- a/BadgeFramework/audio_parser_V0.py
+++ b/BadgeFramework/audio_parser_V0.py
@@ -2,18 +2,19 @@ import numpy as np
 from scipy.io.wavfile import write
 from pathlib import Path
 
-PDM_CRYSTAL_CLK = 32.768e6 # Frequency that feeds the PDM clock generator
+PDM_CRYSTAL_CLK = 32e6 # Frequency that feeds the PDM clock generator
 PDM_TO_PCM_DIV = 64 # https://docs.nordicsemi.com/bundle/ps_nrf52832/page/pdm.html#d931e120
 
 #PDM clock variants taken from https://docs.nordicsemi.com/bundle/ps_nrf52832/page/pdm.html#d931e3773
-PDM_CLK_DIV = 30 # (1.067 MHz CLK variant)
+#PDM_CLK_DIV = 30 # (1.067 MHz CLK variant)
 #PDM_CLK_DIV = 31 # (1.032 MHz CLK variant)
 #PDM_CLK_DIV = 32 # (1 MHz CLK variant)
+PDM_CLK_DIV = 25 # (1.280 MHz CLK variant)
 
 HIGH_SAMPLE_RATE = int((PDM_CRYSTAL_CLK / PDM_CLK_DIV) / PDM_TO_PCM_DIV)
 
 # In LOW mode the midge will store one sample per DECIMATION samples
-DECIMATION = 8
+DECIMATION = 16
 LOW_SAMPLE_RATE = int(HIGH_SAMPLE_RATE/DECIMATION)
 
 def main(fn):

--- a/BadgeFramework/audio_parser_V0.py
+++ b/BadgeFramework/audio_parser_V0.py
@@ -2,8 +2,19 @@ import numpy as np
 from scipy.io.wavfile import write
 from pathlib import Path
 
-HIGH_SAMPLE_RATE = 8000
-LOW_SAMPLE_RATE = 1250
+PDM_CRYSTAL_CLK = 32.768e6 # Frequency that feeds the PDM clock generator
+PDM_TO_PCM_DIV = 64 # https://docs.nordicsemi.com/bundle/ps_nrf52832/page/pdm.html#d931e120
+
+#PDM clock variants taken from https://docs.nordicsemi.com/bundle/ps_nrf52832/page/pdm.html#d931e3773
+PDM_CLK_DIV = 30 # (1.067 MHz CLK variant)
+#PDM_CLK_DIV = 31 # (1.032 MHz CLK variant)
+#PDM_CLK_DIV = 32 # (1 MHz CLK variant)
+
+HIGH_SAMPLE_RATE = int((PDM_CRYSTAL_CLK / PDM_CLK_DIV) / PDM_TO_PCM_DIV)
+
+# In LOW mode the midge will store one sample per DECIMATION samples
+DECIMATION = 8
+LOW_SAMPLE_RATE = int(HIGH_SAMPLE_RATE/DECIMATION)
 
 def main(fn):
     data_folder = Path(fn)
@@ -15,12 +26,11 @@ def main(fn):
 
             path_wav_output = path_raw_input.parent / (path_raw_input.stem + ".wav")
 
+            buffer_dtype = np.int16 # 16-bit PCM
             if path_raw_input.stem[4:6] == "LO":
                 sample_rate = LOW_SAMPLE_RATE  # Low frequency sampling
-                buffer_dtype = np.int16 # 16-bit PCM
             elif path_raw_input.stem[4:6] == "HI":
                 sample_rate = HIGH_SAMPLE_RATE  # High frequency sampling
-                buffer_dtype = np.int32 # 32-bit PCM
             else:
                 raise RuntimeError("Unknown number of channels")
 

--- a/BadgeFramework/badge_protocol.py
+++ b/BadgeFramework/badge_protocol.py
@@ -1048,8 +1048,7 @@ class StartMicrophoneResponse:
 		self.switch_pos= struct.unpack('<b', istream.buf[6])[0]
 
 	def decode_pdm_freq(self, istream):
-		#print("decode_pdm_freq: ", istream.buf)
-		self.pdm_freq= struct.unpack('<B', istream.buf[7])[0]+900
+		self.pdm_freq= struct.unpack('<H', istream.buf[7:9])[0]
 
 
 class StartScanResponse:

--- a/BadgeFramework/test.py
+++ b/BadgeFramework/test.py
@@ -19,7 +19,7 @@ def mic_test(badge, mode):
         # check if mic was started in stereo mode
         if (start_stereo.mode==0):
             print(" mic mode:         PASS            ")
-            if (start_stereo.pdm_freq == 1000 or start_stereo.pdm_freq == 1032 or start_stereo.pdm_freq == 1067):
+            if (start_stereo.pdm_freq == 1280):
                 print(" mic freq:         PASS            ")
             else:
                 print(" mic freq:         FAIL            ")
@@ -59,7 +59,7 @@ def mic_test(badge, mode):
 
         if (start_mono.mode==1):
             print(" mic mode:         PASS            ")
-            if (start_mono.pdm_freq == 1000 or start_mono.pdm_freq == 1032 or start_mono.pdm_freq == 1067):
+            if (start_mono.pdm_freq == 1280):
                 print(" mic freq:         PASS            ")
             else:
                 print(" mic freq:         FAIL            ")

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ CFLAGS += -ffunction-sections -fdata-sections -fno-strict-aliasing
 CFLAGS += -fno-builtin -fshort-enums
 CFLAGS += -D__HEAP_SIZE=1024
 CFLAGS += -D__STACK_SIZE=4096
+CFLAGS += -std=gnu23
 
 # Assembler flags common to all targets
 ASMFLAGS += -g3

--- a/README.md
+++ b/README.md
@@ -223,10 +223,28 @@ bit 3: imu
 
 ### Audio
 
-On "high" audio is stereo, 20kHz, 16bit per channel PCM.
-On "low" it is subsampled by a factor of 32, to 625Hz.
+Audio can be recorded in either stereo o mono. The files saved to the SD cards
+are raw audio files, 16 bit signed PCM. Name of the file indicates the 
+parameters used for recording with the general pattern looking like 
+`[0|1]MIC[HI|LO][audio recording #]`:
 
-It is only timestamped when the file is created (filename is seconds).
+- Name start:
+    - `0`: Stereo
+    - `1`: Mono
+
+- Text after `MIC`:
+    - `HI`: Audio recorded at base platform sample rate aka ("HIGH") frequency (~16KHz)
+    - `LO`: Audio recording where data is decimated to obtain a low-frequency only recording 
+
+> The base platform sample rate is obtained via the calculation: 
+`(PDM_CLK_SOURCE/PDM_CLK_DIVIDER)/PDM_TO_PCM_DIV`. In the current HW, 
+`PDM_CLK_SOURCE` is 32MHz, the `PDM_CLK_DIVIDER` param depends on the microphone
+configuration in firmware, and the `PDM_TO_PCM_DIV` value is 64. The values of
+interest can be found in the nRF5 SDK documentation for the nRF52832 for the 
+PDM peripheral. 
+
+> Decimation factor for low frequency audio is defined in firmware in the 
+`microphone` folder.
 
 ### IMU
 

--- a/microphone/drv_audio_pdm.c
+++ b/microphone/drv_audio_pdm.c
@@ -161,8 +161,12 @@ ret_code_t drv_audio_init(nrf_pdm_mode_t mode)
 
 	pdm_cfg.mode        = local_mode;
 
-	// 20kHz
-	pdm_cfg.clock_freq	= 0x08800000;
+	//! Not officially supported value corresponding to PDM_CLK of 
+	//! NRF_PDM_FREQ_1280K, which will result in a 20KHz sample rate for HI
+	//! position. The HW in the uC is designed for this frequency but Nordic 
+	//! does not support it oficially as it's not considered tested enough 
+	//! https://devzone.nordicsemi.com/f/nordic-q-a/15150/single-pdm-microphone-at-higher-pcm-sampling-rate
+	pdm_cfg.clock_freq	= 0x0A000000UL; 
 	local_freq      = pdm_cfg.clock_freq;
 
 	nrfx_pdm_init(&pdm_cfg, drv_audio_pdm_event_handler);

--- a/microphone/drv_audio_pdm.c
+++ b/microphone/drv_audio_pdm.c
@@ -202,17 +202,20 @@ int16_t drv_audio_get_pdm_freq(void)
 	switch (local_freq) // Valid freqs
 	{
 	case 0x08000000: //1 MHz
-		freq = 100;
+		freq = 1000;
 		break;
 
 	case 0x08400000: //1.032 MHz
-		freq = 132;
+		freq = 1032;
 		break;	
 	case 0x08800000: //1.067 MHz
-		freq = 167;
+		freq = 1067;
+		break;			
+	case 0x0A000000: //1.280 MHz
+		freq = 1280;
 		break;			
 	default:
-		freq = 132;
+		freq = 0;
 		break;
 	}
 	return freq;

--- a/microphone/drv_audio_pdm.h
+++ b/microphone/drv_audio_pdm.h
@@ -8,7 +8,7 @@
 
 #define PDM_BUF_NUM 	2
 #define PDM_BUF_SIZE 	2048
-#define DECIMATION		8 
+#define DECIMATION		16 // 20KHz/16 = 1.250 KHz sample rate for LO position 
 
 typedef struct {
 	int16_t  mic_buf[PDM_BUF_SIZE];

--- a/microphone/drv_audio_pdm.h
+++ b/microphone/drv_audio_pdm.h
@@ -5,10 +5,15 @@
 #include <stdint.h>
 #include "sdk_errors.h"
 #include "nrf_pdm.h"
+#include <assert.h>
 
 #define PDM_BUF_NUM 	2
 #define PDM_BUF_SIZE 	2048
 #define DECIMATION		16 // 20KHz/16 = 1.250 KHz sample rate for LO position 
+
+static_assert((PDM_BUF_SIZE % DECIMATION == 0), "DECIMATION value not allowed,"\
+	" it must be a divisor of PDM_BUF_SIZE");
+
 
 typedef struct {
 	int16_t  mic_buf[PDM_BUF_SIZE];

--- a/microphone/drv_audio_pdm.h
+++ b/microphone/drv_audio_pdm.h
@@ -8,7 +8,7 @@
 
 #define PDM_BUF_NUM 	2
 #define PDM_BUF_SIZE 	2048
-#define DECIMATION		32
+#define DECIMATION		8 
 
 typedef struct {
 	int16_t  mic_buf[PDM_BUF_SIZE];

--- a/rythmbadge/protocol_messages.h
+++ b/rythmbadge/protocol_messages.h
@@ -117,7 +117,7 @@ typedef struct {
 	int8_t gain_l;
 	int8_t gain_r;
 	int8_t switch_pos; //0: OFF, 1: LOW, 2: HIGH
-	int16_t pdm_freq; //137 = 1037
+	uint16_t pdm_freq; // KHz
 } StartMicrophoneResponse;
 
 typedef struct {


### PR DESCRIPTION
Fixes the audio parser script and adds documentation that explains how the frequency for decoding is obtained. Solves #11