### PR TITLE
fix: update RTT address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 _build/*
 *.hex
-_debug.gdb
 *.zip
 *.pyc
 __pycache/

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ load_gdb:
 		echo "Error: Could not find the _SEGGER_RTT address"; \
 		exit 1; \
 	fi; \
-  arm-none-eabi-gdb -se _build/nrf52832_xxaa_debug.out -x _debug.gdb
+  arm-none-eabi-gdb -se _build/nrf52832_xxaa_debug.out -x _build/debug.gdb
 logs: SHELL:=$(shell which bash)   # Use the bash shell for the logs target, as sh does not have the disown command
 logs:
 	socat pty,link=/tmp/ttyvnrf,waitslave tcp:127.0.0.1:8000 & disown

--- a/get_rtt_address.sh
+++ b/get_rtt_address.sh
@@ -13,4 +13,5 @@ else
     exit 1
 fi
 
-envsubst < debug.gdb > _debug.gdb
+# The .gdb env does not support variable expansion directly, so we use envsubst to replace the variable in the file.
+envsubst < debug.gdb > _build/debug.gdb


### PR DESCRIPTION
I was not getting anything out of the logs. I was getting also a `rtt control bock not found` warning message. When I checked the address of the variable, it was not in the address in the `.gdb` file. With the new address it works fine. Are you getting the same error? Is this because I had to update to the arm toolchain 14.2.Rel1 for the `std=gnu23`? Should we automate this somehow?