### PR TITLE
fix: set correct padding value in imu parser

### DIFF
--- a/BadgeFramework/imu_parser.py
+++ b/BadgeFramework/imu_parser.py
@@ -44,7 +44,7 @@ class IMUParser(object):
                     x,y,z = struct.unpack('<fff', data_bytes)
                     data.append([x,y,z])
                     timestamps.append(ts)
-                    i = i + 32
+                    i = i + 24 # 8 timestamp + 12 data + 4 padding
                 else:
                     break
         data_xyz = np.asarray(data)
@@ -117,7 +117,7 @@ class IMUParser(object):
                     q1,q2,q3,q4 = struct.unpack('<ffff', rot_bytes)
                     rotation.append([q1,q2,q3,q4])
                     timestamps.append(ts)
-                    i = i + 32
+                    i = i + 24
                 else:
                     break
         rotation_xyz = np.asarray(rotation)

--- a/README.md
+++ b/README.md
@@ -248,13 +248,13 @@ PDM peripheral.
 
 The IMU data is stored in a binary file.
 The sensors record samples at a best effort of 60Hz, i.e. often there are fewer samples.
-Each sample is 32 bytes long.
-The first 8 bytes contain the timestamp, the next 12 the data and last 12 are padding.
+Each sample is 24 bytes long.
+The first 8 bytes contain the timestamp, the next 12 the data and last 4 bytes are padding.
 
 For example:
 ```
- 2dd4 a69d 016d 0000 0000 3b40 0000 bc48 2000 3f83 0000 000c 0000 ffce 0000 1064
-|---- Timestamp ----|----------  Data  -----------|---------- Padding ----------|
+ 2dd4 a69d 016d 0000 0000 3b40 0000 bc48 2000 3f83 0000 0000
+|---- Timestamp ----|----------  Data  -----------|-- Padding --|
 ```
 
 Timestamp
@@ -275,10 +275,10 @@ The data is 4 bytes float per axis:
 ```
 padding for data alignment, these bytes are ignored
 ```
-0000 000c 0000 ffce 0000 1064
+0000 0000
 ```
 
-The samples for the rotation are different, with 8 bytes for the timestamp, 16 bytes of data and 8 of padding.
+The samples for the rotation are different: 8 bytes for the timestamp and 16 bytes of data.
 The data part represents a quaternion containing 4 floats. 
 
 ### Scanner


### PR DESCRIPTION
In #24 the padding to 32 bits in the data packages was removed, https://github.com/TUDelft-SPC-Lab/midge-code/commit/4a9b3bd7e3e8819569929e1b6b53da63fdf3d072#diff-c404dd58ec668ec2408eaca8916bae0ab81d980d4025125b43d87394f1361ae9L26

Funny that we all missed that change 😅

I considered adding it back but actually I'm guessing that writing 24 bytes is faster than writing 32 and is why Ekin did it that way.

Fixes #39 